### PR TITLE
Adds create method in interfaces (#61)

### DIFF
--- a/src/main/java/org/eclipse/basyx/aas/aggregator/AASAggregator.java
+++ b/src/main/java/org/eclipse/basyx/aas/aggregator/AASAggregator.java
@@ -131,7 +131,7 @@ public class AASAggregator implements IAASAggregator {
 	@Override
 	public void updateAAS(AssetAdministrationShell aas) {
 		MultiSubmodelProvider oldProvider = (MultiSubmodelProvider) getAASProvider(aas.getIdentification());
-		IAASAPI aasApi = aasApiFactory.getAASApi(aas);
+		IAASAPI aasApi = aasApiFactory.create(aas);
 		AASModelProvider contentProvider = new AASModelProvider(aasApi);
 		IConnectorFactory connectorFactory = oldProvider.getConnectorFactory();
 
@@ -142,7 +142,7 @@ public class AASAggregator implements IAASAggregator {
 
 	private MultiSubmodelProvider createMultiSubmodelProvider(AssetAdministrationShell aas) {
 		IConnectorFactory connectorFactory = new HTTPConnectorFactory();
-		IAASAPI aasApi = aasApiFactory.getAASApi(aas);
+		IAASAPI aasApi = aasApiFactory.create(aas);
 		AASModelProvider contentProvider = new AASModelProvider(aasApi);
 		return new MultiSubmodelProvider(contentProvider, registry, connectorFactory, aasApiFactory, submodelAggregatorFactory.create());
 	}

--- a/src/main/java/org/eclipse/basyx/aas/manager/ConnectedAssetAdministrationShellManager.java
+++ b/src/main/java/org/eclipse/basyx/aas/manager/ConnectedAssetAdministrationShellManager.java
@@ -170,7 +170,7 @@ public class ConnectedAssetAdministrationShellManager implements IAssetAdministr
 	public void createAAS(AssetAdministrationShell aas, String endpoint) {
 		endpoint = VABPathTools.stripSlashes(endpoint);
 
-		IModelProvider provider = connectorFactory.getConnector(endpoint);
+		IModelProvider provider = connectorFactory.create(endpoint);
 		AASAggregatorProxy proxy = new AASAggregatorProxy(provider);
 		proxy.createAAS(aas);
 		String combinedEndpoint = VABPathTools.concatenatePaths(endpoint, AASAggregatorAPIHelper.getAASAccessPath(aas.getIdentification()));

--- a/src/main/java/org/eclipse/basyx/aas/restapi/AASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/aas/restapi/AASAPIFactory.java
@@ -32,7 +32,7 @@ public class AASAPIFactory implements IAASAPIFactory {
 
 	@Override
 	public IAASAPI getAASApi(AssetAdministrationShell aas) {
-		return aasAPIFactory.getAASApi(aas);
+		return aasAPIFactory.create(aas);
 	}
 
 }

--- a/src/main/java/org/eclipse/basyx/aas/restapi/MultiSubmodelProvider.java
+++ b/src/main/java/org/eclipse/basyx/aas/restapi/MultiSubmodelProvider.java
@@ -117,7 +117,7 @@ public class MultiSubmodelProvider implements IModelProvider {
 	public MultiSubmodelProvider() {
 		this.setAasApiProvider(new VABAASAPIFactory());
 		this.setSmAggregator(new SubmodelAggregator());
-		IAASAPI aasApi = getAasApiProvider().getAASApi(new AssetAdministrationShell());
+		IAASAPI aasApi = getAasApiProvider().create(new AssetAdministrationShell());
 		setAssetAdministrationShell(new AASModelProvider(aasApi));
 	}
 
@@ -326,7 +326,7 @@ public class MultiSubmodelProvider implements IModelProvider {
 					}
 				}
 
-				List<Submodel> remoteSms = missingEndpoints.stream().map(endpoint -> getConnectorFactory().getConnector(endpoint)).map(p -> (Map<String, Object>) p.getValue("")).map(m -> Submodel.createAsFacade(m))
+				List<Submodel> remoteSms = missingEndpoints.stream().map(endpoint -> getConnectorFactory().create(endpoint)).map(p -> (Map<String, Object>) p.getValue("")).map(m -> Submodel.createAsFacade(m))
 						.collect(Collectors.toList());
 				submodels.addAll(remoteSms);
 			}
@@ -364,7 +364,7 @@ public class MultiSubmodelProvider implements IModelProvider {
 	private void createAssetAdministrationShell(Object newAAS) {
 		Map<String, Object> newAASMap = (Map<String, Object>) newAAS;
 		AssetAdministrationShell shell = AssetAdministrationShell.createAsFacade(newAASMap);
-		IAASAPI aasApi = getAasApiProvider().getAASApi(shell);
+		IAASAPI aasApi = getAasApiProvider().create(shell);
 		aas_provider = new AASModelProvider(aasApi);
 	}
 
@@ -467,7 +467,7 @@ public class MultiSubmodelProvider implements IModelProvider {
 		// Remove "/submodel" since it will be readded later
 		endpoint = endpoint.substring(0, endpoint.length() - SubmodelProvider.SUBMODEL.length() - 1);
 
-		return getConnectorFactory().getConnector(endpoint);
+		return getConnectorFactory().create(endpoint);
 	}
 
 	/**

--- a/src/main/java/org/eclipse/basyx/aas/restapi/api/IAASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/aas/restapi/api/IAASAPIFactory.java
@@ -20,8 +20,14 @@ import org.eclipse.basyx.aas.metamodel.map.AssetAdministrationShell;
 public interface IAASAPIFactory {
 	/**
 	 * Return a constructed AAS API based on a raw model provider
+	 * @deprecated This method is deprecated please use {@link #create(AssetAdministrationShell)}
 	 * 
 	 * @return
 	 */
+	@Deprecated
 	public IAASAPI getAASApi(AssetAdministrationShell aas);
+	
+	public default IAASAPI create(AssetAdministrationShell aas) {
+		return getAASApi(aas);
+	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/authorization/AuthorizedDecoratingAASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/authorization/AuthorizedDecoratingAASAPIFactory.java
@@ -27,6 +27,6 @@ public class AuthorizedDecoratingAASAPIFactory implements IAASAPIFactory {
 
 	@Override
 	public IAASAPI getAASApi(AssetAdministrationShell aas) {
-		return new AuthorizedAASAPI(apiFactory.getAASApi(aas));
+		return new AuthorizedAASAPI(apiFactory.create(aas));
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/aas/api/mqtt/MqttDecoratingAASAPIFactory.java
@@ -34,7 +34,7 @@ public class MqttDecoratingAASAPIFactory implements IAASAPIFactory {
 	@Override
 	public IAASAPI getAASApi(AssetAdministrationShell aas) {
 		try {
-			ObservableAASAPI observedAPI = new ObservableAASAPI(apiFactory.getAASApi(aas));
+			ObservableAASAPI observedAPI = new ObservableAASAPI(apiFactory.create(aas));
 			MqttAASAPIObserver observer = new MqttAASAPIObserver(observedAPI, client);
 			return observedAPI;
 		} catch (MqttException e) {

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/authorization/AuthorizedDecoratingSubmodelAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/authorization/AuthorizedDecoratingSubmodelAPIFactory.java
@@ -27,6 +27,6 @@ public class AuthorizedDecoratingSubmodelAPIFactory implements ISubmodelAPIFacto
 
 	@Override
 	public ISubmodelAPI getSubmodelAPI(Submodel submodel) {
-		return new AuthorizedSubmodelAPI(submodelAPIFactory.getSubmodelAPI(submodel));
+		return new AuthorizedSubmodelAPI(submodelAPIFactory.create(submodel));
 	}
 }

--- a/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/extensions/submodel/mqtt/MqttDecoratingSubmodelAPIFactory.java
@@ -35,7 +35,7 @@ public class MqttDecoratingSubmodelAPIFactory implements ISubmodelAPIFactory {
 	@Override
 	public ISubmodelAPI getSubmodelAPI(Submodel submodel) {
 		try {
-			ObservableSubmodelAPI observedAPI = new ObservableSubmodelAPI(apiFactory.getSubmodelAPI(submodel));
+			ObservableSubmodelAPI observedAPI = new ObservableSubmodelAPI(apiFactory.create(submodel));
 			MqttSubmodelAPIObserver observer = new MqttSubmodelAPIObserver(observedAPI, client);
 			return observedAPI;
 		} catch (MqttException e) {

--- a/src/main/java/org/eclipse/basyx/submodel/aggregator/SubmodelAggregator.java
+++ b/src/main/java/org/eclipse/basyx/submodel/aggregator/SubmodelAggregator.java
@@ -65,7 +65,7 @@ public class SubmodelAggregator implements ISubmodelAggregator {
 
 	@Override
 	public void updateSubmodel(Submodel submodel) throws ResourceNotFoundException {
-		ISubmodelAPI submodelAPI = smApiFactory.getSubmodelAPI(submodel);
+		ISubmodelAPI submodelAPI = smApiFactory.create(submodel);
 		createSubmodel(submodelAPI);
 	}
 	

--- a/src/main/java/org/eclipse/basyx/submodel/restapi/api/ISubmodelAPIFactory.java
+++ b/src/main/java/org/eclipse/basyx/submodel/restapi/api/ISubmodelAPIFactory.java
@@ -20,8 +20,14 @@ import org.eclipse.basyx.submodel.metamodel.map.Submodel;
 public interface ISubmodelAPIFactory {
 	/**
 	 * Return a constructed Submodel API
+	 * @deprecated This method is deprecated please use {@link #create(Submodel)}
 	 * 
 	 * @return
 	 */
+	@Deprecated
 	public ISubmodelAPI getSubmodelAPI(Submodel submodel);
+	
+	public default ISubmodelAPI create(Submodel submodel) {
+		return getSubmodelAPI(submodel);
+	}
 }

--- a/src/main/java/org/eclipse/basyx/submodel/restapi/operation/DelegatedInvocationManager.java
+++ b/src/main/java/org/eclipse/basyx/submodel/restapi/operation/DelegatedInvocationManager.java
@@ -55,7 +55,7 @@ public class DelegatedInvocationManager {
 	public Object invokeDelegatedOperation(Operation operation, Object... parameters) {
 		String delegatedUrl = getDelegatedURL(operation);	
 		return connectorFactory
-				.getConnector(delegatedUrl)
+				.create(delegatedUrl)
 				.invokeOperation("", parameters);
 	}
 	

--- a/src/main/java/org/eclipse/basyx/vab/factory/java/ModelProxyFactory.java
+++ b/src/main/java/org/eclipse/basyx/vab/factory/java/ModelProxyFactory.java
@@ -36,7 +36,7 @@ public class ModelProxyFactory {
 	public VABElementProxy createProxy(String path) {
 		// Create a model provider for the first endpoint
 		String addressEntry = VABPathTools.getFirstEndpoint(path);
-		IModelProvider provider = connectorFactory.getConnector(addressEntry);
+		IModelProvider provider = connectorFactory.create(addressEntry);
 		
 		// Return a proxy for the whole path using the connector to the first endpoint
 		String subPath = VABPathTools.removeFirstEndpoint(path);

--- a/src/main/java/org/eclipse/basyx/vab/gateway/ConnectorProviderMapper.java
+++ b/src/main/java/org/eclipse/basyx/vab/gateway/ConnectorProviderMapper.java
@@ -45,7 +45,7 @@ public class ConnectorProviderMapper implements IConnectorFactory {
 
 	@Override
 	public IModelProvider getConnector(String addr) {
-		return providerMap.get(getPrefix(addr)).getConnector(addr);
+		return providerMap.get(getPrefix(addr)).create(addr);
 	}
 
 	/**

--- a/src/main/java/org/eclipse/basyx/vab/protocol/api/IConnectorFactory.java
+++ b/src/main/java/org/eclipse/basyx/vab/protocol/api/IConnectorFactory.java
@@ -16,6 +16,7 @@ public interface IConnectorFactory {
 
 	/**
 	 * Gets an IModelProvider connecting the specific address.
+	 * @deprecated This method is deprecated please use {@link #create(String)}
 	 *
 	 * @param addr 
 	 * 		The address for which a provider is returned. Must be an address limited to one included endpoint.
@@ -25,5 +26,10 @@ public interface IConnectorFactory {
 	 * 		E.g. the returned model provider for http://localhost/a/b/c directly points to the element c. Therefore, 
 	 * 		getConnector("http://localhost/a/b/c").getModelPropertyValue(""); returns the value of the element c.  
 	 */
+	@Deprecated
 	public IModelProvider getConnector(String addr);
+	
+	public default IModelProvider create(String addr) {
+		return getConnector(addr);
+	}
 }


### PR DESCRIPTION
* Adds create method in interfaces

Description:
- Adds create method in IAASAPIFactory and marks getAASApi as deprecated
- Adds create method in IConnectorFactory and marks getConnector as deprecated
- Adds create method in ISubmodelAPIFactory and marks getSubmodelAPI as deprecated

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>

* Replaces usage of old methods with create method

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>

* Fixes javadoc error

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>